### PR TITLE
[5] Problema ao executar os scripts em uma instância do Google Cloud

### DIFF
--- a/dockerize/bin/artisan.sh
+++ b/dockerize/bin/artisan.sh
@@ -2,8 +2,9 @@
 
 function artisan()
 {
-    T_DIR=$(dirname $(readlink -f ${0}))
-    T_CURRENT=$(basename $(dirname $(readlink -f ${0})))
+    T_0=${0//-}
+    T_DIR=$(dirname $(readlink -f ${T_0}))
+    T_CURRENT=$(basename $(dirname $(readlink -f ${T_0})))
 
     T_DOCKERIZE_BIN="ARTISAN"
 

--- a/dockerize/bin/composer.sh
+++ b/dockerize/bin/composer.sh
@@ -2,8 +2,9 @@
 
 function composer()
 {
-    T_DIR=$(dirname $(readlink -f ${0}))
-    T_CURRENT=$(basename $(dirname $(readlink -f ${0})))
+    T_0=${0//-}
+    T_DIR=$(dirname $(readlink -f ${T_0}))
+    T_CURRENT=$(basename $(dirname $(readlink -f ${T_0})))
 
     T_DOCKERIZE_BIN="COMPOSER"
 

--- a/dockerize/bin/node.sh
+++ b/dockerize/bin/node.sh
@@ -2,8 +2,9 @@
 
 function node()
 {
-    T_DIR=$(dirname $(readlink -f ${0}))
-    T_CURRENT=$(basename $(dirname $(readlink -f ${0})))
+    T_0=${0//-}
+    T_DIR=$(dirname $(readlink -f ${T_0}))
+    T_CURRENT=$(basename $(dirname $(readlink -f ${T_0})))
 
     T_DOCKERIZE_BIN="NODE"
 

--- a/dockerize/bin/npm.sh
+++ b/dockerize/bin/npm.sh
@@ -2,8 +2,9 @@
 
 function npm()
 {
-    T_DIR=$(dirname $(readlink -f ${0}))
-    T_CURRENT=$(basename $(dirname $(readlink -f ${0})))
+    T_0=${0//-}
+    T_DIR=$(dirname $(readlink -f ${T_0}))
+    T_CURRENT=$(basename $(dirname $(readlink -f ${T_0})))
 
     T_DOCKERIZE_BIN="NPM"
 

--- a/dockerize/bin/php.sh
+++ b/dockerize/bin/php.sh
@@ -2,8 +2,9 @@
 
 function php()
 {
-    T_DIR=$(dirname $(readlink -f ${0}))
-    T_CURRENT=$(basename $(dirname $(readlink -f ${0})))
+    T_0=${0//-}
+    T_DIR=$(dirname $(readlink -f ${T_0}))
+    T_CURRENT=$(basename $(dirname $(readlink -f ${T_0})))
 
     T_DOCKERIZE_BIN="PHP"
 

--- a/dockerize/bin/quasar.sh
+++ b/dockerize/bin/quasar.sh
@@ -2,8 +2,9 @@
 
 function quasar()
 {
-    T_DIR=$(dirname $(readlink -f ${0}))
-    T_CURRENT=$(basename $(dirname $(readlink -f ${0})))
+    T_0=${0//-}
+    T_DIR=$(dirname $(readlink -f ${T_0}))
+    T_CURRENT=$(basename $(dirname $(readlink -f ${T_0})))
 
     T_DOCKERIZE_BIN="QUASAR"
 

--- a/dockerize/bin/vue.sh
+++ b/dockerize/bin/vue.sh
@@ -2,8 +2,9 @@
 
 function vue()
 {
-    T_DIR=$(dirname $(readlink -f ${0}))
-    T_CURRENT=$(basename $(dirname $(readlink -f ${0})))
+    T_0=${0//-}
+    T_DIR=$(dirname $(readlink -f ${T_0}))
+    T_CURRENT=$(basename $(dirname $(readlink -f ${T_0})))
 
     T_DOCKERIZE_BIN="VUE"
 

--- a/dockerize/bin/yarn.sh
+++ b/dockerize/bin/yarn.sh
@@ -2,8 +2,9 @@
 
 function yarn()
 {
-    T_DIR=$(dirname $(readlink -f ${0}))
-    T_CURRENT=$(basename $(dirname $(readlink -f ${0})))
+    T_0=${0//-}
+    T_DIR=$(dirname $(readlink -f ${T_0}))
+    T_CURRENT=$(basename $(dirname $(readlink -f ${T_0})))
 
     T_DOCKERIZE_BIN="YARN"
 

--- a/dockerize/dockerize-run.sh
+++ b/dockerize/dockerize-run.sh
@@ -52,7 +52,8 @@ function __run()
 
 function __env
 {
-    DOCKERIZE_ENV=$(dirname $(readlink -f ${0}))
+    T_0=${0//-}
+    DOCKERIZE_ENV=$(dirname $(readlink -f ${T_0}))
     if [[ ! -f ${DOCKERIZE_ENV}/.dockerize ]]; then
       return
     fi


### PR DESCRIPTION
Ao se executar o script, dentro das funções que executam o comando no contêiner, o parâmetro ${0} chega com um traço na frente impedindo a execução dos mesmos.

Ex.:
Na máquina local, o parâmetro esperado pela função é 'bash', assim sendo, o comando total fica sendo:
$(readlink -f ${0}))
$(readlink -f 'bash')

Na instancia da VM no Google Cloud, não sei o porque, mas o parâmetro ${0} chega com - na frente do bash, assim sendo:
$(readlink -f '-bash')
resultado no erro:
readlink: opção inválida -- “b”